### PR TITLE
Comparing performance - Loop & Single Expression 

### DIFF
--- a/ch2/exercise2-3/main.go
+++ b/ch2/exercise2-3/main.go
@@ -1,0 +1,22 @@
+package popcount
+
+// pc[i] is the population count of i.
+var pc [256]byte
+
+func init() {
+	for i := range pc {
+		pc[i] = pc[i/2] + byte(i&1)
+	}
+}
+
+// PopCount returns the population count (number of set bits) of x.
+func PopCount(x uint64) int {
+	return int(pc[byte(x>>(0*8))] +
+		pc[byte(x>>(1*8))] +
+		pc[byte(x>>(2*8))] +
+		pc[byte(x>>(3*8))] +
+		pc[byte(x>>(4*8))] +
+		pc[byte(x>>(5*8))] +
+		pc[byte(x>>(6*8))] +
+		pc[byte(x>>(7*8))])
+}

--- a/ch2/exercise2-3/popcount.go
+++ b/ch2/exercise2-3/popcount.go
@@ -20,3 +20,11 @@ func PopCount(x uint64) int {
 		pc[byte(x>>(6*8))] +
 		pc[byte(x>>(7*8))])
 }
+
+func PopCountLoop(x uint64) int {
+	var count byte
+	for i := 8; i > 0; i-- {
+		count = count + pc[byte(x>>((i-1)*8))]
+	}
+	return int(count)
+}

--- a/ch2/exercise2-3/popcount_test.go
+++ b/ch2/exercise2-3/popcount_test.go
@@ -1,0 +1,19 @@
+package popcount_test
+
+import (
+	"testing"
+
+	popcount "./"
+)
+
+func BenchmarkSingleExpression(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcount.PopCount(0x123456789ABCDEF)
+	}
+}
+
+func BenchmarkLoop(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcount.PopCountLoop(0x123456789ABCDEF)
+	}
+}


### PR DESCRIPTION
Ran twice. It seems that the single expression is significantly faster.  

## Output 1: 
```
goos: linux
goarch: amd64
BenchmarkSingleExpression-12    	1000000000	         0.494 ns/op
BenchmarkLoop-12                	84505893	        13.7 ns/op
PASS
ok  	_/home/quin/tgpl-chapter2/ch2/exercise2-3	1.723s

```


## Output 2: 

```
goos: linux
goarch: amd64
BenchmarkSingleExpression-12    	1000000000	         0.524 ns/op
BenchmarkLoop-12                	84073848	        14.2 ns/op
PASS
ok  	_/home/quin/tgpl-chapter2/ch2/exercise2-3	1.797s
```