### PR TITLE
Exercise2 4

### DIFF
--- a/ch2/exercise2-4/popcount.go
+++ b/ch2/exercise2-4/popcount.go
@@ -1,0 +1,22 @@
+package popcount
+
+// pc[i] is the population count of i.
+var pc [256]byte
+
+func init() {
+	for i := range pc {
+		pc[i] = pc[i/2] + byte(i&1)
+	}
+}
+
+// PopCount returns the population count (number of set bits) of x.
+func PopCount(x uint64) int {
+	return int(pc[byte(x>>(0*8))] +
+		pc[byte(x>>(1*8))] +
+		pc[byte(x>>(2*8))] +
+		pc[byte(x>>(3*8))] +
+		pc[byte(x>>(4*8))] +
+		pc[byte(x>>(5*8))] +
+		pc[byte(x>>(6*8))] +
+		pc[byte(x>>(7*8))])
+}

--- a/ch2/exercise2-4/popcount.go
+++ b/ch2/exercise2-4/popcount.go
@@ -20,3 +20,14 @@ func PopCount(x uint64) int {
 		pc[byte(x>>(6*8))] +
 		pc[byte(x>>(7*8))])
 }
+
+func PopCountShift(x uint64) int {
+	var count int
+	for i := 0; i < 64; i++ { // shift through 64 bit positions
+		if x&1 > 0 {
+			count++
+		}
+		x = x >> 1 // x = x / 2^1
+	}
+	return count
+}

--- a/ch2/exercise2-4/popcount_test.go
+++ b/ch2/exercise2-4/popcount_test.go
@@ -1,0 +1,19 @@
+package popcount_test
+
+import (
+	"testing"
+
+	popcount "./"
+)
+
+func BenchmarkSingleExpression(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcount.PopCount(0x123456789ABCDEF)
+	}
+}
+
+func BenchmarkShift(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		popcount.PopCountShift(0x123456789ABCDEF)
+	}
+}


### PR DESCRIPTION
PopCountSingleExpression still has better performance 

```
goos: linux
goarch: amd64
BenchmarkSingleExpression-12    	1000000000	         0.489 ns/op
BenchmarkShift-12               	24941292	        47.0 ns/op
PASS
ok  	_/home/quin/tgpl-chapter2/ch2/exercise2-4	1.812s
```
```
goos: linux
goarch: amd64
BenchmarkSingleExpression-12    	1000000000	         0.473 ns/op
BenchmarkShift-12               	25293138	        45.9 ns/op
PASS
ok  	_/home/quin/tgpl-chapter2/ch2/exercise2-4	1.774s
``` 

